### PR TITLE
Make sure overridden templates are actually used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install -e .
   - pip install -r requirements/tests.txt Django==$DJANGO
 before_script:
-  - flake8 sorter --ignore=E501
+  - flake8 sorter --ignore=E501,E128
 script:
   - make test
 env:

--- a/sorter/templates/tests/sorter/sortlink_sort_test.html
+++ b/sorter/templates/tests/sorter/sortlink_sort_test.html
@@ -1,0 +1,1 @@
+I am a pretty custom template but i feel ignored.

--- a/sorter/templatetags/sorter_tags.py
+++ b/sorter/templatetags/sorter_tags.py
@@ -167,7 +167,7 @@ class SortURL(SorterAsTag):
         name = data.get('with')
         template_names = [self._meta.template_name]
         if name and name != settings.SORTER_DEFAULT_QUERY_NAME:
-            template_names.append(u'%s_%s' % (self._meta.template_name, name))
+            template_names.insert(0, u'%s_%s' % (self._meta.template_name, name))
         return [u"sorter/%s.html" % name for name in template_names]
 
 

--- a/sorter/test_settings.py
+++ b/sorter/test_settings.py
@@ -1,3 +1,5 @@
+import os
+
 SITE_ID = 1
 
 DATABASES = {
@@ -18,3 +20,10 @@ INSTALLED_APPS = [
 TEST_RUNNER = 'discover_runner.DiscoverRunner'
 
 SECRET_KEY = 'something-something'
+
+BASE_DIR = os.path.dirname(__file__)
+
+TEMPLATE_DIRS=(
+    os.path.join(BASE_DIR, 'templates'),
+    os.path.join(BASE_DIR, 'templates', 'tests'),
+)

--- a/sorter/test_settings.py
+++ b/sorter/test_settings.py
@@ -23,7 +23,7 @@ SECRET_KEY = 'something-something'
 
 BASE_DIR = os.path.dirname(__file__)
 
-TEMPLATE_DIRS=(
+TEMPLATE_DIRS = (
     os.path.join(BASE_DIR, 'templates'),
     os.path.join(BASE_DIR, 'templates', 'tests'),
 )

--- a/sorter/tests.py
+++ b/sorter/tests.py
@@ -170,6 +170,7 @@ class SortURLTests(SorterTestCase):
             """{% sorturl by "creation_date" %}""",
             """/?sort=creation_date""")
 
+
 class SortlinkTests(SorterTestCase):
 
     def test_simple(self):

--- a/sorter/tests.py
+++ b/sorter/tests.py
@@ -170,7 +170,6 @@ class SortURLTests(SorterTestCase):
             """{% sorturl by "creation_date" %}""",
             """/?sort=creation_date""")
 
-
 class SortlinkTests(SorterTestCase):
 
     def test_simple(self):
@@ -197,6 +196,11 @@ class SortlinkTests(SorterTestCase):
         self.assertViewRaises(TemplateSyntaxError,
             """{% sortlink with "objects" by "creation_date,-title" %}"""
             """{% endsortlink %}""")
+
+    def test_template_override(self):
+        self.assertViewRenders(
+            """{% sortlink with "test" by "creation_date,-title" %}Creation and title{% endsortlink %}""",
+            """I am a pretty custom template but i feel ignored.""")
 
 
 class SortFormTests(SorterTestCase):


### PR DESCRIPTION
Hey Jannis,

i followed the docs (https://django-sorter.readthedocs.org/en/latest/usage.html#further-customization) for specifying a custom template for the sortlink tag but my custom template never got picked up and i always ended up with the default template.

Looking at the code I'd say the problem is that currently the default template is always listed first  in the list of templates passed to the template. Changing the order seems to do the trick.