### PR TITLE
Order view

### DIFF
--- a/sorter/utils.py
+++ b/sorter/utils.py
@@ -1,5 +1,6 @@
 from itertools import tee, izip, chain
-
+from fnmatch import fnmatch
+from sorter.conf import settings
 
 def cycle_pairs(iterable):
     """
@@ -11,3 +12,22 @@ def cycle_pairs(iterable):
     a, b = tee(iterable)
     iter(b).next()
     return chain(izip(a, b), [(last, first)])
+
+def ordering(self, request, name):
+    """
+    Given the request and the name of the sorting
+    should return a list of ordering values.
+    """
+    try:
+        sort_fields = request.GET[name].split(',')
+    except (KeyError, ValueError, TypeError):
+        return []
+    result = []
+    allowed_criteria = settings.SORTER_ALLOWED_CRITERIA.get(name)
+    if allowed_criteria is None:
+        return result
+    for sort_field in sort_fields:
+        for criteria in allowed_criteria:
+            if fnmatch(sort_field.lstrip('-'), criteria):
+                result.append(sort_field)
+    return result

--- a/sorter/utils.py
+++ b/sorter/utils.py
@@ -13,7 +13,7 @@ def cycle_pairs(iterable):
     iter(b).next()
     return chain(izip(a, b), [(last, first)])
 
-def ordering(self, request, name):
+def ordering(request, name):
     """
     Given the request and the name of the sorting
     should return a list of ordering values.

--- a/sorter/views.py
+++ b/sorter/views.py
@@ -1,0 +1,35 @@
+from utils import ordering
+
+class Ordered(object):
+    """Generic mixin view for ordering a queryset.
+    """
+
+    # Name of the order criteria, from settings, that will be used to sort the queryset
+    order_by_criteria = None
+
+    def get_order_by_criteria(self, queryset):
+        return self.order_by_criteria
+
+    def order_queryset(self, queryset, order_by_criteria):
+        order_by = ordering(self.request, order_by_criteria)
+        if order_by:
+            return queryset.order_by(*order_by)
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        queryset = kwargs.pop('object_list')
+        order_by_criteria = self.get_order_by_criteria(queryset)
+        if order_by_criteria:
+            context = {
+                'is_ordered': True,
+                'object_list': self.order_queryset(queryset, order_by_criteria)
+            }
+        else:
+            context = {
+                'is_ordered': False,
+                'object_list': queryset
+            }
+
+        context.update(kwargs)
+
+        return super(Ordered, self).get_context_data(**context)


### PR DESCRIPTION
Using the sort tag with a generic list view that has pagination throws an error because the queryset has already been sliced. I created a generic view mixin, Ordered, that uses the settings provided by django-sorter.